### PR TITLE
dt fix instances.tf bastion dns_server_list

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -100,7 +100,7 @@ resource "vsphere_virtual_machine" "bastion" {
       # set the default gateway to public if available.  TODO: static routes for private network
       ipv4_gateway    = "${var.public_gateway != "" ? var.public_gateway : var.private_gateway}"
 
-      dns_server_list = ["${concat(var.private_dns_servers, var.public_dns_servers)}"]
+      dns_server_list = compact(concat(var.private_dns_servers, var.public_dns_servers))
       dns_suffix_list = compact(list(var.private_domain, var.public_domain))
     }
   }


### PR DESCRIPTION
The bastion node VM customization, specifically, the dns_server_list parameter value is different between instances_ds_cluster.tf and instances.tf. The instances_ds_cluster.tf version is correct and the instances.tf version causes an error about expecting type string. This fixes the instances.tf parameter to match the parameter in instances_ds_cluster.tf, which is correct.